### PR TITLE
Added certificate-ripper to the AUR and updated README accordingly

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -31,10 +31,16 @@ crip print --url=https://stackoverflow.com/
 4. Run `start /b "" "crip.exe" print --url=https://stackoverflow.com/`
 
 ### Linux
-1. Download the latest binary here: [Releases](https://github.com/Hakky54/certificate-ripper/releases)
-2. Extract the compressed file
-3. Add the reference to your environment variables: `export CRIP_HOME=/path/to/crip/binary`
-4. Run `crip print --url=https://stackoverflow.com/`
+
+#### Arch-Linux (AUR)
+1. Install the [certificate-ripper-bin](https://aur.archlinux.org/packages/certificate-ripper-bin) AUR package
+2. Run `crip print --url=https://stackoverflow.com/`
+
+#### From Source
+4. Download the latest binary here: [Releases](https://github.com/Hakky54/certificate-ripper/releases)
+5. Extract the compressed file
+6. Add the reference to your environment variables: `export CRIP_HOME=/path/to/crip/binary`
+7. Run `crip print --url=https://stackoverflow.com/`
 
 ### Using Executable JAR
 **Minimum requirements:**

--- a/README.MD
+++ b/README.MD
@@ -32,15 +32,17 @@ crip print --url=https://stackoverflow.com/
 
 ### Linux
 
-#### Arch-Linux (AUR)
-1. Install the [certificate-ripper-bin](https://aur.archlinux.org/packages/certificate-ripper-bin) AUR package
-2. Run `crip print --url=https://stackoverflow.com/`
-
 #### From Source
 1. Download the latest binary here: [Releases](https://github.com/Hakky54/certificate-ripper/releases)
 2. Extract the compressed file
 3. Add the reference to your environment variables: `export CRIP_HOME=/path/to/crip/binary`
 4. Run `crip print --url=https://stackoverflow.com/`
+
+#### Contributed/Unofficial Installation Methods
+
+##### Arch-Linux (AUR)
+1. Install the [certificate-ripper-bin](https://aur.archlinux.org/packages/certificate-ripper-bin) AUR package
+2. Run `crip print --url=https://stackoverflow.com/`
 
 ### Using Executable JAR
 **Minimum requirements:**

--- a/README.MD
+++ b/README.MD
@@ -37,10 +37,10 @@ crip print --url=https://stackoverflow.com/
 2. Run `crip print --url=https://stackoverflow.com/`
 
 #### From Source
-4. Download the latest binary here: [Releases](https://github.com/Hakky54/certificate-ripper/releases)
-5. Extract the compressed file
-6. Add the reference to your environment variables: `export CRIP_HOME=/path/to/crip/binary`
-7. Run `crip print --url=https://stackoverflow.com/`
+1. Download the latest binary here: [Releases](https://github.com/Hakky54/certificate-ripper/releases)
+2. Extract the compressed file
+3. Add the reference to your environment variables: `export CRIP_HOME=/path/to/crip/binary`
+4. Run `crip print --url=https://stackoverflow.com/`
 
 ### Using Executable JAR
 **Minimum requirements:**


### PR DESCRIPTION
Hi,

First of all, congratulations for your awesome work with `certificate-ripper`.

I added it to the AUR ([Arch User Repository](https://wiki.archlinux.org/title/Arch_User_Repository)), so Arch Linux users (and Arch Linux based distros users in general) can benefit from an easy and automated installation (and update) process for `certificate-ripper`. 
I hope it's okay for you ! :)

You can view the `certificate-ripper(-bin)` AUR package [here](https://aur.archlinux.org/packages/certificate-ripper-bin) and its PKGBUILD [here](https://aur.archlinux.org/cgit/aur.git/tree/PKGBUILD?h=certificate-ripper-bin).
I'm obviously down to maintain it on the AUR for all the future updates `certificate-ripper` will get !

If that's okay for you, I modified the README of the Github repo to let people know that `certificate-ripper` is now available on the AUR as well (hence this PR), but I would totally understand if you don't want to (for instance, if you don't want to consider it as an "official" way of installing `certificate-ripper`).
If that's so, I'll understand if you reject my PR ;)

Don't hesitate to reach me if you need more info.
Once again, thanks for your work !