### PR TITLE
Improve nixpkgs example code

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -52,8 +52,8 @@ crip print --url=https://stackoverflow.com/
 1. Install the [certificate-ripper-bin](https://aur.archlinux.org/packages/certificate-ripper-bin) AUR package
 2. Run `crip print --url=https://stackoverflow.com/`
 
-##### NixOs
-1. Run `nix-env -f https://github.com/NixOS/nixpkgs/archive/master.tar.gz -iA certificate-ripper`
+##### NixOS (nixpkgs)
+1. Run `nix-shell -p certificate-ripper` or add `pkgs.certificate-ripper` to your `configuration.nix` file
 2. Run `crip print --url=https://stackoverflow.com/`
 
 ### Using Executable JAR


### PR DESCRIPTION
This PR changes the use of `nix-env` to `nix-shell`

It is much more common to use `nix-shell` and I personally would not recommend `nix-env` to anyone (even if nixpkgs uses it a lot in the examples)

The updated example will only work if your local version of `nixpkgs` already has `certificate-ripper`

Until then, you'd need to write `nix-shell -I nixpkgs=https://github.com/NixOS/nixpkgs/archive/master.tar.gz -p certificate-ripper`

There are some more modern ways of writing this example, like `nix shell nixpkgs#certificate-ripper` but that's locked behind an "experimental" flag.