### PR TITLE
Improve performance

### DIFF
--- a/src/main/java/nl/altindag/crip/command/SharedProperties.java
+++ b/src/main/java/nl/altindag/crip/command/SharedProperties.java
@@ -72,7 +72,9 @@ public class SharedProperties {
                 .parallel()
                 .map(url -> {
                     try {
-                        return new AbstractMap.SimpleEntry<>(url, createClient().get(url));
+                        CertificateExtractingClient client = createClient();
+                        List<X509Certificate> certificates = client.get(url);
+                        return new AbstractMap.SimpleEntry<>(url, certificates);
                     } catch (GenericIOException e) {
                         System.out.printf("Could not extract from %s%n", url);
                         return null;

--- a/src/main/java/nl/altindag/crip/command/SharedProperties.java
+++ b/src/main/java/nl/altindag/crip/command/SharedProperties.java
@@ -32,7 +32,7 @@ import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Objects;
+import java.util.Optional;
 import java.util.stream.Collectors;
 
 import static nl.altindag.ssl.util.internal.StringUtils.isNotBlank;
@@ -74,13 +74,14 @@ public class SharedProperties {
                     try {
                         CertificateExtractingClient client = createClient();
                         List<X509Certificate> certificates = client.get(url);
-                        return new AbstractMap.SimpleEntry<>(url, certificates);
+                        return Optional.of(new AbstractMap.SimpleEntry<>(url, certificates));
                     } catch (GenericIOException e) {
                         System.out.printf("Could not extract from %s%n", url);
-                        return null;
+                        return Optional.<AbstractMap.SimpleEntry<String, List<X509Certificate>>>empty();
                     }
                 })
-                .filter(Objects::nonNull)
+                .filter(Optional::isPresent)
+                .map(Optional::get)
                 .collect(Collectors.collectingAndThen(Collectors.toMap(AbstractMap.SimpleEntry::getKey, AbstractMap.SimpleEntry::getValue, (key1, key2) -> key1, LinkedHashMap::new), HashMap::new));
 
         if (urls.contains(SYSTEM)) {


### PR DESCRIPTION
I noticed a slow performance when running the following command:

> ```crip export p12 -u=https://google.com -u=https://youtube.com -u=https://facebook.com -u=https://instagram.com -u=https://whatsapp.com -u=https://x.com -u=https://wikipedia.org -u=https://chatgpt.com -u=https://reddit.com -u=https://yahoo.com -u=https://yahoo.co.jp -u=https://amazon.com -u=https://yandex.ru -u=https://baidu.com -u=https://tiktok.com -u=https://netflix.com -u=https://bing.com -u=https://pornhub.com -u=https://linkedin.com -u=https://live.com -u=https://dzen.ru -u=https://office.com -u=https://microsoft.com -u=https://xvideos.com -u=https://pinterest.com -u=https://bilibili.com -u=https://twitch.tv -u=https://vk.com -u=https://news.yahoo.co.jp -u=https://xhamster.com -u=https://mail.ru -u=https://sharepoint.com -u=https://samsung.com -u=https://fandom.com -u=https://globo.com -u=https://canva.com -u=https://xnxx.com -u=https://duckduckgo.com -u=https://t.me -u=https://weather.com -u=https://quora.com -u=https://temu.com -u=https://cnn.com -u=https://zoom.us -u=https://stripchat.com -u=https://ebay.com -u=https://walmart.com -u=https://aliexpress.com -u=https://taobao.com -u=https://jd.com -u=https://sina.com.cn -u=https://weibo.com -u=https://t.co -u=https://csdn.net -u=https://alipay.com -u=https://detail.tmall.com -u=https://tumblr.com -u=https://google.ru -u=https://google.fr -u=https://google.de -u=https://so.com -u=https://baidu.com -u=https://google.com.hk -u=https://amazon.co.jp -u=https://stackoverflow.com -u=https://mail.ru -u=https://okezone.com -u=https://google.co.in -u=https://office.com -u=https://msn.com -u=https://paypal.com -u=https://bilibili.com -u=https://hao123.com -u=https://imdb.com -u=https://t.co -u=https://fandom.com -u=https://imgur.com -u=https://xhamster.com -u=https://163.com -u=https://wordpress.com -u=https://apple.com -u=https://soso.com -u=https://google.com.br -u=https://booking.com -u=https://xinhuanet.com -u=https://adobe.com -u=https://pinterest.com -u=https://amazon.de -u=https://amazon.in -u=https://dropbox.com -u=https://bongacams.com -u=https://google.co.jp -u=https://babytree.com -u=https://detail.tmall.com -u=https://tumblr.com -u=https://google.ru -u=https://google.fr -u=https://t.co -u=https://quora.com -u=https://bbc.com -u=https://r7.com -u=https://dailymotion.com -u=https://soundcloud.com -u=https://usatoday.com -u=https://nytimes.com -u=https://forbes.com -u=https://businessinsider.com -u=https://news.com.au -u=https://cnn.co.uk -u=https://euronews.com -u=https://sky.com -u=https://huffpost.com -u=https://reuters.com -u=https://bbc.co.uk -u=https://weather.gov -u=https://theguardian.com -u=https://washingtonpost.com -u=https://mirror.co.uk -u=https://time.com -u=https://cnbc.com -u=https://usnews.com -u=https://theverge.com -u=https://techcrunch.com -u=https://gizmodo.com -u=https://engadget.com -u=https://arstechnica.com -u=https://wired.com -u=https://macrumors.com -u=https://cnet.com -u=https://tomshardware.com -u=https://androidcentral.com -u=https://pcmag.com -u=https://slashdot.org -u=https://bgr.com -u=https://venturebeat.com -u=https://theinformation.com -u=https://businessweek.com -u=https://electrek.co -u=https://cultofmac.com -u=https://9to5mac.com -u=https://georgemagazine.com -u=https://webmd.com -u=https://healthline.com -u=https://medicalnewstoday.com -u=https://mayoclinic.org -u=https://everydayhealth.com -u=https://verywellhealth.com -u=https://health.com -u=https://livestrong.com -u=https://self.com -u=https://medicaldaily.com -u=https://scientificamerican.com -u=https://livescience.com -u=https://nationalgeographic.com -u=https://smithsonianmag.com -u=https://sciencedaily.com -u=https://bbc.com -u=https://discovery.com```

It took 35 seconds in total.
With this PR it is reduced to 2 seconds